### PR TITLE
New version of mpstat is putting NULL byte at the end of values. Upda…

### DIFF
--- a/mpstat2node.py
+++ b/mpstat2node.py
@@ -168,7 +168,9 @@ def average_over_node(cpu_numa, cpu_on_node, cpu_nb, nodes_nb):
         words = line[11:].split()
         cpu = words[0]
         for col in range(STAT_COLUMNS):
-            statistics[col][int(cpu_numa[cpu])] += float(words[col + 1])
+            #print repr(words[col + 1])
+            statistics[col][int(cpu_numa[cpu])] += float(words[col + 1].strip('\0'))
+
 
     # Statistics over nodes:
     for node in range(nodes_nb):


### PR DESCRIPTION
…te script accordingly

New version of mpstat is putting NULL byte at the end of values:
04:33:58 AM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle$
04:34:03 AM  all   62.11^@    0.00^@    0.05^@    0.00^@    0.05^@    0.01^@    0.00^@    0.00^@    0.00^@   37.78^@$
04:34:03 AM    0   64.07^@    0.00^@    0.00^@    0.00^@    0.00^@    0.20^@    0.00^@    0.00^@    0.00^@   35.73^@$
04:34:03 AM    1   64.40^@    0.00^@    0.00^@    0.00^@    0.00^@    0.00^@    0.00^@    0.00^@    0.00^@   35.60^@$

This is causing this error:

04:27:13 AM NODE    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
04:27:18 AM  all    3.15    0.00    0.07    0.00    0.01    0.01    0.00    0.00    0.00   96.77
Traceback (most recent call last):
  File "/tmp/MPSTAT2NODE/mpstat2node.py", line 194, in <module>
    modify_mpstat_output(cpu_numa, cpu_on_node, cpu_nb, nodes_nb)
  File "/tmp/MPSTAT2NODE/mpstat2node.py", line 133, in modify_mpstat_output
    status = average_over_node(cpu_numa, cpu_on_node, cpu_nb, nodes_nb)
  File "/tmp/MPSTAT2NODE/mpstat2node.py", line 171, in average_over_node
    statistics[col][int(cpu_numa[cpu])] += float(words[col + 1])
ValueError: invalid literal for float(): 0.00

This patch fixes this problem.